### PR TITLE
Update python-can Initialization to 'interface' parameter Instead of deprecated 'bustype'

### DIFF
--- a/botwheel-explorer/bot_ctrl.py
+++ b/botwheel-explorer/bot_ctrl.py
@@ -408,7 +408,7 @@ async def main():
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
     local_ip_addresses = get_local_ips_1()
-    bus = can.interface.Bus(args.can, bustype="socketcan")
+    bus = can.interface.Bus(args.can, interface="socketcan")
 
     # Flush CAN RX buffer so there are no more old pending messages
     while not (bus.recv(timeout=0) is None): pass

--- a/examples/can_calibrate.py
+++ b/examples/can_calibrate.py
@@ -18,7 +18,7 @@ async def main():
     args = parser.parse_args()
 
     print("opening CAN bus...")
-    with can.interface.Bus(args.channel, bustype=args.interface, bitrate=args.bitrate) as bus:
+    with can.interface.Bus(args.channel, interface=args.interface, bitrate=args.bitrate) as bus:
         with CanSimpleNode(bus=bus, node_id=args.node_id) as node:
             node.clear_errors_msg()
             node.set_state_msg(3) # AxisState.FULL_CALIBRATION_SEQUENCE

--- a/examples/can_enumerate.py
+++ b/examples/can_enumerate.py
@@ -270,7 +270,7 @@ async def main():
                 sys.exit(1)
             user_addresses[parts[0]] = num
 
-    with can.interface.Bus(args.channel, bustype=args.interface, bitrate=args.bitrate) as bus:
+    with can.interface.Bus(args.channel, interface=args.interface, bitrate=args.bitrate) as bus:
         if args.reboot_all:
             print("Broadcasting reboot command...")
             reboot_msg(bus, BROADCAST_NODE_ID, REBOOT_ACTION_REBOOT)

--- a/examples/can_param_access.py
+++ b/examples/can_param_access.py
@@ -24,7 +24,7 @@ node_id = 0 # must match the configured node_id on your ODrive (default 0)
 # -- end definitions
 
 import can
-bus = can.interface.Bus("can0", bustype="socketcan")
+bus = can.interface.Bus("can0", interface="socketcan")
 
 # When using ODrive USB-CAN adapter:
 # bus = can.interface.Bus(index=0, channel=0, bitrate=1000000, interface="gs_usb")

--- a/examples/can_restore_config.py
+++ b/examples/can_restore_config.py
@@ -111,7 +111,7 @@ async def main():
         config_list = json.load(f)
 
     print("opening CAN bus...")
-    with can.interface.Bus(args.channel, bustype=args.interface, bitrate=args.bitrate) as bus:
+    with can.interface.Bus(args.channel, interface=args.interface, bitrate=args.bitrate) as bus:
         #reader = can.AsyncBufferedReader()
         #notifier = can.Notifier(bus, [reader], loop=asyncio.get_running_loop())
         with CanSimpleNode(bus=bus, node_id=args.node_id) as node:

--- a/examples/can_simple.py
+++ b/examples/can_simple.py
@@ -15,7 +15,7 @@ import struct
 
 node_id = 0 # must match `<odrv>.axis0.config.can.node_id`. The default is 0.
 
-bus = can.interface.Bus("can0", bustype="socketcan")
+bus = can.interface.Bus("can0", interface="socketcan")
 
 # Flush CAN RX buffer so there are no more old pending messages
 while not (bus.recv(timeout=0) is None): pass


### PR DESCRIPTION
While working with the CAN examples today, I noticed the DeprecationWarning (which appears in python-can versions 4.2.0 and later). At some point, it became annoying enough to address. I propose replacing the deprecated `bustype` parameter in the python-can library with `interface` in the CAN bus initialization code across the example scripts.

I recognize that this direct replacement may introduce backward incompatibility with python-can versions prior to 4.0.0, as those releases do not support the `interface` parameter. To mitigate this, we can use a compatibility wrapper with a `try`-`except` block for fallback behavior:

```python
import can

try:
    # python-can >= 4.0.0
    bus = can.Bus(interface='socketcan', channel='can0')
except (AttributeError, ValueError):
    # fallback for python-can < 4.0.0
    bus = can.interface.Bus(bustype='socketcan', channel='can0')
```

However, for this PR, I decided to keep it simple and not include this wrapper. Given that python-can 4.0.0 has been available since early 2022 and the `bustype` parameter is slated for complete removal in version 5.0.0, this update might be needed anyway, perhaps not now, but later in a future python-can release, so you can accept it when there is a need. I would be happy to add the proposed compatibility wrapper instead if you think it might be better option.

I tested the updated scripts on Python 3.14 with python-can 4.6.1.

I welcome feedback and am available to make further adjustments. Thank you for considering this contribution.